### PR TITLE
Introduce strum and strum_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "bitflags"
@@ -82,9 +82,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -104,11 +104,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -143,9 +143,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
@@ -171,6 +171,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
@@ -200,18 +206,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683751d591e6d81200c39fb0d1032608b77724f34114db54f571ff1317b337c0"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c11e44798ad209ccdd91fc192f0526a369a01234f7373e1b141c96d7cee4f0e"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -227,20 +233,22 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "pigment64"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "byteorder",
  "clap",
  "num_enum",
  "png",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.10"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -261,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -278,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,9 +299,28 @@ checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ repository = "https://github.com/decompals/pigment64"
 license = "MIT"
 
 [dependencies]
-png = "0.17.10"
-clap = { version = "4.4.13", features = ["derive"] }
-anyhow = "1.0.79"
+png = "0.17.13"
+clap = { version = "4.5.4", features = ["derive"] }
+anyhow = "1.0.81"
 byteorder = "1.5.0"
-num_enum = "0.7.1"
+num_enum = "0.7.2"
+strum = "0.26.2"
+strum_macros = "0.26.2"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# pigment64
+pigment64 is a library written in Rust for decoding N64 images in to pngs.
+
+## Formats
+The library supports the following image formats:
+- I1, I4, I8, Ia4, Ia8, Ia16, Ci4, Ci8, RGBA16, RGBA32

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pigment64
-pigment64 is a library written in Rust for decoding N64 images in to pngs.
+pigment64 is a library written in Rust for converting image data between native and png formats.
 
 ## Formats
 The library supports the following image formats:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,7 @@ pub use image::png_image::PNGImage;
 
 mod utils;
 
-use strum:: {
-    EnumCount, IntoEnumIterator
-};
-use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+use strum_macros::{EnumCount, EnumIter};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
 #[repr(u8)]
@@ -26,6 +23,15 @@ pub enum ImageSize {
 }
 
 impl ImageSize {
+    /// Returns the size of the TLUT (Table Look-Up Table) based on the image size.
+    ///
+    /// # Returns
+    ///
+    /// The size of the TLUT as a `usize` value.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the image size is invalid.
     pub fn get_tlut_size(&self) -> usize {
         match self {
             ImageSize::Bits1 => 0b10,
@@ -55,7 +61,7 @@ pub enum ImageFormat {
 /// Each variant corresponds to a specific image type, such as indexed color (Ci), grayscale (I),
 /// grayscale with alpha (Ia), or red-green-blue-alpha (RGBA).
 ///
-#[derive(Copy, Clone, Debug, PartialEq, EnumCountMacro, EnumIter, Eq, Hash, TryFromPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, EnumCount, EnumIter, Eq, Hash, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ImageType {
     I1,
@@ -116,38 +122,6 @@ impl ImageType {
             ImageType::Rgba32 => ImageFormat::Rgba,
         }
     }
-
-    /// Returns the number of variants in the `ImageType` enum.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use pigment64::ImageType;
-    ///
-    /// // Get the count of ImageType variants
-    /// let count = ImageType::get_image_type_count();
-    /// println!("Number of ImageType variants: {}", count);
-    /// ```
-    pub fn get_count() -> usize {
-        ImageType::COUNT
-    }
-
-    /// Returns an iterator over all possible variants of `ImageType`, converted to their formatted
-    /// string representations.
-    ///
-    /// # Examples
-    /// ```
-    /// use pigment64::ImageType;
-    ///
-    /// // Iterate over the image formats
-    /// for image_format_type in ImageType::format_iter() {
-    ///     println!("{}", image_format_type);
-    /// }
-    /// ```
-    pub fn get_iter() -> impl Iterator<Item = ImageType> {
-        ImageType::iter().into_iter()
-    }
-
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,11 @@ pub use image::png_image::PNGImage;
 
 mod utils;
 
+use strum:: {
+    EnumCount, IntoEnumIterator
+};
+use strum_macros::{EnumCount as EnumCountMacro, EnumIter};
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ImageSize {
@@ -43,7 +48,14 @@ pub enum ImageFormat {
     I = 4,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, TryFromPrimitive)]
+/// Represents the type of image.
+///
+/// This enum is used to specify the type of image, which determines the size and format of the
+/// image data.
+/// Each variant corresponds to a specific image type, such as indexed color (Ci), grayscale (I),
+/// grayscale with alpha (Ia), or red-green-blue-alpha (RGBA).
+///
+#[derive(Copy, Clone, Debug, PartialEq, EnumCountMacro, EnumIter, Eq, Hash, TryFromPrimitive)]
 #[repr(u8)]
 pub enum ImageType {
     I1,
@@ -59,6 +71,14 @@ pub enum ImageType {
 }
 
 impl ImageType {
+    /// Returns the size of the image type.
+    ///
+    /// This function returns the size of the image type, which represents the number of bits used
+    /// to store each pixel. The size is determined based on the image type variant.
+    ///
+    /// # Returns
+    ///
+    /// - `ImageSize` - The size of the image type.
     pub fn get_size(&self) -> ImageSize {
         match self {
             ImageType::Ci4 => ImageSize::Bits4,
@@ -74,6 +94,14 @@ impl ImageType {
         }
     }
 
+    /// Returns the format of the image type.
+    ///
+    /// This method returns the format of the image type, which represents the color model used by
+    /// the image. The format is determined based on the image type variant.
+    ///
+    /// # Returns
+    ///
+    /// - `ImageFormat` - The format of the image type.
     pub fn get_format(&self) -> ImageFormat {
         match self {
             ImageType::Ci4 => ImageFormat::Ci,
@@ -88,6 +116,38 @@ impl ImageType {
             ImageType::Rgba32 => ImageFormat::Rgba,
         }
     }
+
+    /// Returns the number of variants in the `ImageType` enum.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pigment64::ImageType;
+    ///
+    /// // Get the count of ImageType variants
+    /// let count = ImageType::get_image_type_count();
+    /// println!("Number of ImageType variants: {}", count);
+    /// ```
+    pub fn get_count() -> usize {
+        ImageType::COUNT
+    }
+
+    /// Returns an iterator over all possible variants of `ImageType`, converted to their formatted
+    /// string representations.
+    ///
+    /// # Examples
+    /// ```
+    /// use pigment64::ImageType;
+    ///
+    /// // Iterate over the image formats
+    /// for image_format_type in ImageType::format_iter() {
+    ///     println!("{}", image_format_type);
+    /// }
+    /// ```
+    pub fn get_iter() -> impl Iterator<Item = ImageType> {
+        ImageType::iter().into_iter()
+    }
+
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TryFromPrimitive)]

--- a/tests/native_image.rs
+++ b/tests/native_image.rs
@@ -166,7 +166,6 @@ fn rgba32() -> Result<()> {
 
 #[test]
 fn test_image_type_strum() {
-
     // Test iterating over the ImageType enum
     let mut image_iter = ImageType::iter();
     assert_eq!(Some(ImageType::I1), image_iter.next());

--- a/tests/native_image.rs
+++ b/tests/native_image.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use pigment64::image::native_image::parse_tlut;
 use pigment64::{create_palette_from_png, ImageSize, ImageType, NativeImage, PNGImage, TextureLUT};
+use strum::{EnumCount, IntoEnumIterator};
 
 #[test]
 fn ci4() -> Result<()> {
@@ -161,4 +162,25 @@ fn rgba32() -> Result<()> {
 
     assert_eq!(output_bytes, original_bytes);
     Ok(())
+}
+
+#[test]
+fn test_format_names() {
+
+    let mut image_iter = ImageType::iter();
+    assert_eq!(Some(ImageType::I1), image_iter.next());
+    assert_eq!(Some(ImageType::I4), image_iter.next());
+    assert_eq!(Some(ImageType::I8), image_iter.next());
+    assert_eq!(Some(ImageType::Ia4), image_iter.next());
+    assert_eq!(Some(ImageType::Ia8), image_iter.next());
+    assert_eq!(Some(ImageType::Ia16), image_iter.next());
+    assert_eq!(Some(ImageType::Ci4), image_iter.next());
+    assert_eq!(Some(ImageType::Ci8), image_iter.next());
+    assert_eq!(Some(ImageType::Rgba16), image_iter.next());
+    assert_eq!(Some(ImageType::Rgba32), image_iter.next());
+    assert_eq!(None, image_iter.next());
+
+    // Test the Correct number of items
+    assert_eq!(10, ImageType::COUNT);
+    assert_eq!(ImageType::iter().count(), ImageType::COUNT);
 }

--- a/tests/native_image.rs
+++ b/tests/native_image.rs
@@ -165,8 +165,9 @@ fn rgba32() -> Result<()> {
 }
 
 #[test]
-fn test_format_names() {
+fn test_image_type_strum() {
 
+    // Test iterating over the ImageType enum
     let mut image_iter = ImageType::iter();
     assert_eq!(Some(ImageType::I1), image_iter.next());
     assert_eq!(Some(ImageType::I4), image_iter.next());


### PR DESCRIPTION
- This commit introduces the usage of the `strum` and `strum_macros` crates. The purpose of these crates is to enable the usage of getting the variant counts and an iterator for the enumeration.

- Some documentation was added for enums and their functions.

- Added a basic README.md

- Bumped versions in Cargo.toml